### PR TITLE
CPDBDS-331 | making policies optional

### DIFF
--- a/charts/diskover/templates/deployment-server.yaml
+++ b/charts/diskover/templates/deployment-server.yaml
@@ -44,8 +44,10 @@ spec:
         #   name: localtime
         # - mountPath: /etc/timezone
         #   name: timezone
+{{- if .Values.policies.enabled }}
         dnsPolicy: ClusterFirst
         restartPolicy: Always
+{{- end }}
         env:
         - name: RUN_MODE
           value: "SERVER"

--- a/charts/diskover/templates/deployment-server.yaml
+++ b/charts/diskover/templates/deployment-server.yaml
@@ -44,10 +44,8 @@ spec:
         #   name: localtime
         # - mountPath: /etc/timezone
         #   name: timezone
-{{- if .Values.policies.enabled }}
-        dnsPolicy: ClusterFirst
-        restartPolicy: Always
-{{- end }}
+        #dnsPolicy: ClusterFirst
+        #restartPolicy: Always
         env:
         - name: RUN_MODE
           value: "SERVER"

--- a/charts/diskover/templates/deployment-worker.yaml
+++ b/charts/diskover/templates/deployment-worker.yaml
@@ -45,8 +45,10 @@ spec:
         #   name: localtime
         # - mountPath: /etc/timezone
         #   name: timezone
+{{- if .Values.policies.enabled }}
         dnsPolicy: ClusterFirst
         restartPolicy: Always
+{{ end }}
         env:
         - name: RUN_MODE
           value: "WORKER"

--- a/charts/diskover/templates/deployment-worker.yaml
+++ b/charts/diskover/templates/deployment-worker.yaml
@@ -45,10 +45,8 @@ spec:
         #   name: localtime
         # - mountPath: /etc/timezone
         #   name: timezone
-{{- if .Values.policies.enabled }}
-        dnsPolicy: ClusterFirst
-        restartPolicy: Always
-{{ end }}
+        #dnsPolicy: ClusterFirst
+        #restartPolicy: Always
         env:
         - name: RUN_MODE
           value: "WORKER"

--- a/charts/diskover/values.yaml
+++ b/charts/diskover/values.yaml
@@ -60,3 +60,5 @@ resources:
     cpu: 1
     memory: 512Mi
 probePath: /actuator/health
+policies:
+  enabled: true

--- a/charts/diskover/values.yaml
+++ b/charts/diskover/values.yaml
@@ -60,5 +60,3 @@ resources:
     cpu: 1
     memory: 512Mi
 probePath: /actuator/health
-policies:
-  enabled: true


### PR DESCRIPTION
Removing dnsPolicy and restartPolicy as these properties are added by default