### PR TITLE
CPDBDS-331 | update config name

### DIFF
--- a/charts/diskover/templates/configmap-diskover.yaml
+++ b/charts/diskover/templates/configmap-diskover.yaml
@@ -177,4 +177,4 @@ data:
     ; pagesize = 1000
 kind: ConfigMap
 metadata:
-  name: {{ .Chart.Name }}-config
+  name: {{ template "fullname" . }}-config

--- a/charts/diskover/templates/deployment-server.yaml
+++ b/charts/diskover/templates/deployment-server.yaml
@@ -64,6 +64,6 @@ spec:
           items:
           - key: diskover.cfg
             path: diskover.cfg
-          name: {{ .Chart.Name }}-config
+          name: {{ template "fullname" . }}-config
         name: diskover-config
 

--- a/charts/diskover/templates/deployment-worker.yaml
+++ b/charts/diskover/templates/deployment-worker.yaml
@@ -63,6 +63,6 @@ spec:
           items:
           - key: diskover.cfg
             path: diskover.cfg
-          name: {{ .Chart.Name }}-config
+          name: {{ template "fullname" . }}-config
         name: diskover-config
 


### PR DESCRIPTION
Changes to update config name to be derived based on Release name rather than just Chart name. This change is needed to support multiple diskover servers in one namespace. 